### PR TITLE
Add chirp and fixed-frequency control modes

### DIFF
--- a/src/SPIN_COMM_test_script.py
+++ b/src/SPIN_COMM_test_script.py
@@ -17,107 +17,243 @@ Copyright (c) 2021-2024 LAAS-CNRS
 SPDX-License-Identifier: LGLPV2.1
 """
 
-"""
-@brief  This is a class for the factory test of Twitst 1.4.1
+# High-level communication script used to drive the OwnTech converter from a PC.
+#
+# The script connects to the shield, prepares the selected leg and launches
+# three automated tests sequentially:
+#   1. Réponse à l'échelon (``TEST_SENSI``)
+#   2. Balayage fréquentiel (``TEST_CHIRP``)
+#   3. Sinusoïde à fréquence fixe (``TEST_FIXED_FREQ``)
+#
+# After each excitation the scope dump streamed by the firmware is decoded,
+# summarised on stdout and archived to
+# ``scope_records/<horodatage>_<test>.csv`` so the user can inspect the
+# captured waveforms offline.
 
-@author Luiz Villa <luiz.villa@laas.fr>
-@author Guillaume Arthaud <thomas.walter@laas.fr>
-"""
+from __future__ import annotations
 
-import serial,  find_devices
+import csv
+import os
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import List, Tuple
+
+import find_devices
+
 from Shield_Class import Shield_Device
-# from owntech.lib.USB.comm_protocol.src.Shield_Class import Shield_Device
-
-shield_vid = 0x2fe3
-shield_pid = 0x0101
-
-Shield_ports = find_devices.find_shield_device_ports(shield_vid, shield_pid)
-print(Shield_ports)
-
-if not Shield_ports:
-    raise SystemExit(
-        "Unable to automatically locate an OwnTech shield. "
-        "Verify that the board is connected and recognized by the OS, "
-        "or pass the desired serial port explicitly to Shield_Device."
-    )
-
-Shield = Shield_Device(shield_port= Shield_ports[0], shield_type= "TWIST")
 
 
-message = Shield.sendCommand("IDLE")
-print(message)
-message = Shield.sendCommand("POWER_ON")
-print(message)
-available_measurements = set(Shield.get_supported_measurements())
-for measurement_name in ("V1", "V2", "V3"):
-    if measurement_name in available_measurements:
-        message = Shield.getMeasurement(measurement_name)
-        print(message)
-    else:
-        print(
-            f"Measurement {measurement_name} is not available for {Shield.shield_type} "
-            "shields."
+SHIELD_VID = 0x2FE3
+SHIELD_PID = 0x0101
+DEFAULT_LEG = "LEG2"
+
+
+def discover_port() -> str:
+    """Return the serial port used by the shield, favouring an override."""
+
+    override = os.environ.get("OWNTECH_PORT")
+    if override:
+        print(f"OWNTECH_PORT défini, utilisation du port {override}")
+        return override
+
+    ports = find_devices.find_shield_device_ports(SHIELD_VID, SHIELD_PID)
+    print(f"Ports OwnTech détectés: {ports}")
+    if not ports:
+        raise SystemExit(
+            "Impossible de localiser automatiquement une carte OwnTech. "
+            "Branchez la carte ou fournissez le port via la variable "
+            "d'environnement OWNTECH_PORT."
         )
 
-message = Shield.sendCommand("POWER_OFF")
-print(message)
-message = Shield.sendCommand("DUTY", "LEG1", 0.01)
-print(message)
-message = Shield.sendCommand("CAPA", "LEG1", "ON")
-print(message)
-message = Shield.sendCommand( "BUCK", "LEG3", "ON")
-print(message)
-message = Shield.sendCommand( "BUCK", "LEG2", "ON")
-print(message)
-message = Shield.sendCommand( "BOOST", "LEG1", "ON")
-print(message)
-message = Shield.sendCommand("LEG","LEG2","ON")
-print(message)
-message = Shield.sendCommand("DRIVER","LEG2","ON")
-print(message)
-message = Shield.sendCommand("DRIVER","LEG1","ON")
-print(message)
-message = Shield.sendCommand("DRIVER","LEG3","ON")
-print(message)
+    if len(ports) > 1:
+        print(
+            "Plusieurs ports correspondent au VID/PID OwnTech. Utilisation du premier."
+        )
+
+    return ports[0]
 
 
+def send_and_log(shield: Shield_Device, action: str, *args, delay: float = 0.2) -> str:
+    """Wrapper utilitaire pour afficher chaque commande envoyée."""
 
-#---------------REFERENCE TEST------------------------------------
-leg_to_test = "LEG2"
-reference_names = ["V1","V2","VH","I1","I2","IH"]
-reference_values = [1, 2, 3, 4, 5, 6]
-
-message1 = Shield.sendCommand("IDLE")
-print(message1)
-
-#---------------AUTOMATED EXCITATION EXAMPLES-------------------
-# Launches a chirp excitation (start frequency, end frequency, duration,
-# optional amplitude, optional offset, optional loop flag)
-message = Shield.sendCommand("TEST_CHIRP", "LEG2", 50.0, 5000.0, 2.0)
-print(message)
-
-# Launches a fixed frequency sinusoidal drive (frequency, optional amplitude,
-# optional offset)
-message = Shield.sendCommand("TEST_FIXED_FREQ", "LEG2", 500.0, 0.4, 0.5)
-print(message)
-
-# Stops any automated excitation currently running on LEG2
-message = Shield.sendCommand("TEST_WAVE_STOP", "LEG2")
-print(message)
-
-message1 = Shield.sendCommand("DRIVER",leg_to_test,"ON")
-print(message1)
+    message = shield.sendCommand(action, *args, delay=delay)
+    print(f"→ {message}")
+    return message
 
 
+def ensure_leg_ready(shield: Shield_Device, leg: str) -> None:
+    """Met la carte sous tension et active la jambe testée."""
 
-for reference, reference_values in zip(reference_names, reference_values):
-    message1 = Shield.sendCommand("POWER_OFF")
-    print(message1)
-    message1 = Shield.sendCommand("REFERENCE",leg_to_test,reference,reference_values)
-    print(message1)
-    message1 = Shield.sendCommand("POWER_ON")
-    print(message1)
+    print(f"Préparation de {leg} pour les essais automatiques…")
+    send_and_log(shield, "IDLE")
+    send_and_log(shield, "POWER_ON")
+    send_and_log(shield, "LEG", leg, "ON")
+    send_and_log(shield, "CAPA", leg, "ON")
+    send_and_log(shield, "DRIVER", leg, "ON", delay=1.0)
 
 
-message1 = Shield.sendCommand("IDLE")
-print(message1)
+def analyze_record(test_name: str, record: dict) -> None:
+    """Calcule quelques statistiques simples sur les données capturées."""
+
+    columns: Tuple[str, ...] = record.get("columns", ())
+    samples: List[dict] = record.get("samples", [])
+
+    print(f"Analyse du scope pour {test_name} : {len(samples)} échantillons")
+
+    if not columns or not samples:
+        print("  Aucune donnée disponible dans l'enregistrement.")
+        return
+
+    for column in columns:
+        values = [sample[column] for sample in samples if column in sample]
+        if not values:
+            continue
+
+        minimum = min(values)
+        maximum = max(values)
+        average = sum(values) / len(values)
+        print(
+            f"  {column:<18} min={minimum:>8.4f}  max={maximum:>8.4f}  "
+            f"moyenne={average:>8.4f}  départ={values[0]:>8.4f}  fin={values[-1]:>8.4f}"
+        )
+
+
+def persist_record(test_name: str, record: dict) -> None:
+    """Sauvegarde l'enregistrement décodé au format CSV et brut."""
+
+    samples: List[dict] = record.get("samples", [])
+    columns: Tuple[str, ...] = record.get("columns", ())
+    raw_payload: Tuple[str, ...] = record.get("raw", ())
+
+    if not samples or not columns:
+        print("  Rien à sauvegarder pour ce test.")
+        return
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    safe_name = test_name.lower().replace(" ", "_")
+    out_dir = Path("scope_records")
+    out_dir.mkdir(exist_ok=True)
+
+    csv_path = out_dir / f"{timestamp}_{safe_name}.csv"
+    with csv_path.open("w", newline="") as csv_file:
+        writer = csv.writer(csv_file)
+        writer.writerow(columns)
+        for sample in samples:
+            writer.writerow([sample.get(column, "") for column in columns])
+
+    raw_path = out_dir / f"{timestamp}_{safe_name}.txt"
+    with raw_path.open("w", encoding="utf-8") as raw_file:
+        raw_file.write("#" + ",".join(columns) + "\n")
+        index_value = record.get("index")
+        if index_value is not None:
+            raw_file.write(f"#{index_value}\n")
+        for line in raw_payload:
+            raw_file.write(f"{line}\n")
+
+    print(f"  Enregistrements sauvegardés dans {csv_path} et {raw_path}.")
+
+
+def capture_scope(shield: Shield_Device, timeout: float) -> dict:
+    """Attend l'enregistrement du scope et retourne sa structure décodée."""
+
+    try:
+        record = shield.wait_for_scope_record(timeout=timeout)
+    except TimeoutError as exc:
+        print(f"  ⚠️  Timeout pendant la récupération du scope : {exc}")
+        return {"columns": (), "samples": (), "raw": ()}
+    except RuntimeError as exc:
+        print(f"  ⚠️  Erreur lors du décodage du scope : {exc}")
+        return {"columns": (), "samples": (), "raw": ()}
+
+    return record
+
+
+def run_sensitivity_test(shield: Shield_Device, leg: str, vref: float) -> None:
+    print("\n=== Test de sensibilité (réponse à l'échelon) ===")
+    shield.getSerialObjID().reset_input_buffer()
+    send_and_log(shield, "TEST_SENSI", leg, vref, delay=0.5)
+    record = capture_scope(shield, timeout=30.0)
+    analyze_record("TEST_SENSI", record)
+    persist_record("TEST_SENSI", record)
+
+
+def run_chirp_test(
+    shield: Shield_Device,
+    leg: str,
+    start_freq: float,
+    end_freq: float,
+    duration: float,
+    amplitude: float = 0.4,
+    offset: float = 0.5,
+    loop: int = 0,
+) -> None:
+    print("\n=== Test chirp (balayage fréquentiel) ===")
+    shield.getSerialObjID().reset_input_buffer()
+    send_and_log(
+        shield,
+        "TEST_CHIRP",
+        leg,
+        start_freq,
+        end_freq,
+        duration,
+        amplitude,
+        offset,
+        loop,
+        delay=0.5,
+    )
+    record = capture_scope(shield, timeout=max(duration + 10.0, 20.0))
+    analyze_record("TEST_CHIRP", record)
+    persist_record("TEST_CHIRP", record)
+
+
+def run_fixed_frequency_test(
+    shield: Shield_Device,
+    leg: str,
+    frequency: float,
+    amplitude: float = 0.4,
+    offset: float = 0.5,
+    run_duration: float = 2.0,
+) -> None:
+    print("\n=== Test sinusoïdal à fréquence fixe ===")
+    serial_obj = shield.getSerialObjID()
+    serial_obj.reset_input_buffer()
+    send_and_log(shield, "TEST_FIXED_FREQ", leg, frequency, amplitude, offset, delay=0.5)
+    print(f"  Maintien de l'onde pendant {run_duration} s avant arrêt…")
+    time.sleep(max(run_duration, 0.5))
+    send_and_log(shield, "TEST_WAVE_STOP", leg, delay=0.5)
+    record = capture_scope(shield, timeout=20.0)
+    analyze_record("TEST_FIXED_FREQ", record)
+    persist_record("TEST_FIXED_FREQ", record)
+
+
+def main() -> int:
+    port = discover_port()
+    shield = Shield_Device(shield_port=port, shield_type="TWIST")
+
+    leg = DEFAULT_LEG
+    ensure_leg_ready(shield, leg)
+
+    # Lecture rapide des tensions principales pour vérifier la communication.
+    for measurement_name in ("V1", "V2", "V3"):
+        try:
+            value = shield.getMeasurement(measurement_name)
+        except ValueError:
+            print(f"Mesure {measurement_name} indisponible pour ce shield.")
+        else:
+            print(f"{measurement_name} = {value:.3f}")
+
+    run_sensitivity_test(shield, leg, vref=15.0)
+    run_chirp_test(shield, leg, start_freq=50.0, end_freq=5000.0, duration=2.0)
+    run_fixed_frequency_test(shield, leg, frequency=500.0, amplitude=0.4, offset=0.5)
+
+    send_and_log(shield, "POWER_OFF")
+    send_and_log(shield, "IDLE")
+
+    print("\nSéquence de tests terminée.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/SPIN_COMM_test_script.py
+++ b/src/SPIN_COMM_test_script.py
@@ -88,6 +88,12 @@ def ensure_leg_ready(shield: Shield_Device, leg: str) -> None:
 
     print(f"Préparation de {leg} pour les essais automatiques…")
     send_and_log(shield, "IDLE")
+    rearm_leg(shield, leg)
+
+
+def rearm_leg(shield: Shield_Device, leg: str) -> None:
+    """Assure que la jambe de test est prête pour un nouvel essai."""
+
     send_and_log(shield, "POWER_ON")
     send_and_log(shield, "LEG", leg, "ON")
     send_and_log(shield, "CAPA", leg, "ON")
@@ -172,6 +178,7 @@ def capture_scope(shield: Shield_Device, timeout: float) -> dict:
 
 def run_sensitivity_test(shield: Shield_Device, leg: str, vref: float) -> None:
     print("\n=== Test de sensibilité (réponse à l'échelon) ===")
+    rearm_leg(shield, leg)
     shield.getSerialObjID().reset_input_buffer()
     send_and_log(shield, "TEST_SENSI", leg, vref, delay=0.5)
     record = capture_scope(shield, timeout=30.0)
@@ -190,6 +197,7 @@ def run_chirp_test(
     loop: int = 0,
 ) -> None:
     print("\n=== Test chirp (balayage fréquentiel) ===")
+    rearm_leg(shield, leg)
     shield.getSerialObjID().reset_input_buffer()
     send_and_log(
         shield,
@@ -218,6 +226,7 @@ def run_fixed_frequency_test(
 ) -> None:
     print("\n=== Test sinusoïdal à fréquence fixe ===")
     serial_obj = shield.getSerialObjID()
+    rearm_leg(shield, leg)
     serial_obj.reset_input_buffer()
     send_and_log(shield, "TEST_FIXED_FREQ", leg, frequency, amplitude, offset, delay=0.5)
     print(f"  Maintien de l'onde pendant {run_duration} s avant arrêt…")

--- a/src/SPIN_COMM_test_script.py
+++ b/src/SPIN_COMM_test_script.py
@@ -48,12 +48,16 @@ message = Shield.sendCommand("IDLE")
 print(message)
 message = Shield.sendCommand("POWER_ON")
 print(message)
-message = Shield.getMeasurement('V1')
-print(message)
-message = Shield.getMeasurement('V2')
-print(message)
-message = Shield.getMeasurement('V3')
-print(message)
+available_measurements = set(Shield.get_supported_measurements())
+for measurement_name in ("V1", "V2", "V3"):
+    if measurement_name in available_measurements:
+        message = Shield.getMeasurement(measurement_name)
+        print(message)
+    else:
+        print(
+            f"Measurement {measurement_name} is not available for {Shield.shield_type} "
+            "shields."
+        )
 
 message = Shield.sendCommand("POWER_OFF")
 print(message)

--- a/src/SPIN_COMM_test_script.py
+++ b/src/SPIN_COMM_test_script.py
@@ -79,6 +79,21 @@ reference_values = [1, 2, 3, 4, 5, 6]
 message1 = Shield.sendCommand("IDLE")
 print(message1)
 
+#---------------AUTOMATED EXCITATION EXAMPLES-------------------
+# Launches a chirp excitation (start frequency, end frequency, duration,
+# optional amplitude, optional offset, optional loop flag)
+message = Shield.sendCommand("TEST_CHIRP", "LEG2", 50.0, 5000.0, 2.0)
+print(message)
+
+# Launches a fixed frequency sinusoidal drive (frequency, optional amplitude,
+# optional offset)
+message = Shield.sendCommand("TEST_FIXED_FREQ", "LEG2", 500.0, 0.4, 0.5)
+print(message)
+
+# Stops any automated excitation currently running on LEG2
+message = Shield.sendCommand("TEST_WAVE_STOP", "LEG2")
+print(message)
+
 message1 = Shield.sendCommand("DRIVER",leg_to_test,"ON")
 print(message1)
 

--- a/src/SPIN_COMM_test_script.py
+++ b/src/SPIN_COMM_test_script.py
@@ -34,6 +34,13 @@ shield_pid = 0x0101
 Shield_ports = find_devices.find_shield_device_ports(shield_vid, shield_pid)
 print(Shield_ports)
 
+if not Shield_ports:
+    raise SystemExit(
+        "Unable to automatically locate an OwnTech shield. "
+        "Verify that the board is connected and recognized by the OS, "
+        "or pass the desired serial port explicitly to Shield_Device."
+    )
+
 Shield = Shield_Device(shield_port= Shield_ports[0], shield_type= "TWIST")
 
 

--- a/src/SPIN_COMM_test_script.py
+++ b/src/SPIN_COMM_test_script.py
@@ -131,7 +131,7 @@ def persist_record(test_name: str, record: dict) -> None:
         print("  Rien à sauvegarder pour ce test.")
         return
 
-    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
     safe_name = test_name.lower().replace(" ", "_")
     out_dir = Path("scope_records")
     out_dir.mkdir(exist_ok=True)
@@ -245,7 +245,9 @@ def main() -> int:
             print(f"{measurement_name} = {value:.3f}")
 
     run_sensitivity_test(shield, leg, vref=15.0)
+    time.sleep(1.0)
     run_chirp_test(shield, leg, start_freq=50.0, end_freq=5000.0, duration=2.0)
+    time.sleep(1.0)
     run_fixed_frequency_test(shield, leg, frequency=500.0, amplitude=0.4, offset=0.5)
 
     send_and_log(shield, "POWER_OFF")

--- a/src/Shield_Class.py
+++ b/src/Shield_Class.py
@@ -222,6 +222,10 @@ class Shield_Device:
                 - "REFERENCE": Sets the reference value for a specific variable on the Twist board.
                 - "DUTY": Sets the duty cycle value for a specific leg on the Twist board.
                 - "CALIBRATE": Calibrates a specific variable on the Twist board.
+                - "TEST_SENSI": Launches the step-response sensitivity test on the selected leg.
+                - "TEST_CHIRP": Launches a chirp excitation on the selected leg.
+                - "TEST_FIXED_FREQ": Runs a fixed-frequency sinusoidal excitation on the selected leg.
+                - "TEST_WAVE_STOP": Stops any ongoing automated excitation (step, chirp or fixed frequency).
             *args: Optional arguments corresponding to the action.
             delay (float, optional): The delay (in seconds) after sending the command. Default is 0.2 seconds.
 
@@ -236,7 +240,20 @@ class Shield_Device:
             >>> sendCommand("LEG", "A", "ON")
         """
 
-        action_types = ("LEG", "CAPA", "DRIVER", "BUCK", "BOOST", "REFERENCE", "DUTY", "CALIBRATE")
+        action_types = (
+            "LEG",
+            "CAPA",
+            "DRIVER",
+            "BUCK",
+            "BOOST",
+            "REFERENCE",
+            "DUTY",
+            "CALIBRATE",
+            "TEST_SENSI",
+            "TEST_CHIRP",
+            "TEST_FIXED_FREQ",
+            "TEST_WAVE_STOP",
+        )
 
         # Dictionary mapping actions to their message formats
         message_formats = {
@@ -252,6 +269,23 @@ class Shield_Device:
             "DUTY": lambda leg, value: f"s_{leg.upper()}_d_{value:.5f}",
             "CALIBRATE": lambda variable, gain, offset: f"k_{variable.upper()}_g_{gain:.8f}_o_{offset:.8f}",
             "TEST_SENSI": lambda leg, value: f"t_{leg.upper()}_r_{value:.1f}",
+            "TEST_CHIRP": (
+                lambda leg,
+                       f_start,
+                       f_end,
+                       duration,
+                       amplitude=0.4,
+                       offset=0.5,
+                       loop=0: (
+                    f"t_{leg.upper()}_c_{f_start:.2f}_{f_end:.2f}_{duration:.3f}_{amplitude:.3f}_{offset:.3f}_{int(loop)}"
+                )
+            ),
+            "TEST_FIXED_FREQ": (
+                lambda leg, frequency, amplitude=0.4, offset=0.5: (
+                    f"t_{leg.upper()}_f_{frequency:.2f}_{amplitude:.3f}_{offset:.3f}"
+                )
+            ),
+            "TEST_WAVE_STOP": lambda leg: f"t_{leg.upper()}_s",
             }
 
         # Check if action is valid

--- a/src/Shield_Class.py
+++ b/src/Shield_Class.py
@@ -26,6 +26,7 @@ SPDX-License-Identifier: LGLPV2.1
 """
 
 #Python modules import
+import inspect
 import time, serial
 
 class Shield_Device:
@@ -253,21 +254,6 @@ class Shield_Device:
             >>> sendCommand("LEG", "A", "ON")
         """
 
-        action_types = (
-            "LEG",
-            "CAPA",
-            "DRIVER",
-            "BUCK",
-            "BOOST",
-            "REFERENCE",
-            "DUTY",
-            "CALIBRATE",
-            "TEST_SENSI",
-            "TEST_CHIRP",
-            "TEST_FIXED_FREQ",
-            "TEST_WAVE_STOP",
-        )
-
         # Dictionary mapping actions to their message formats
         message_formats = {
             "IDLE": "d_i",
@@ -305,8 +291,21 @@ class Shield_Device:
         if action not in message_formats:
             raise ValueError(f"Invalid action: {action}")
 
-        # Generate message based on action and arguments
-        message = message_formats[action](*args) if action in action_types else message_formats[action]
+        formatter = message_formats[action]
+        if callable(formatter):
+            try:
+                message = formatter(*args)
+            except TypeError as exc:
+                signature = inspect.signature(formatter)
+                raise ValueError(
+                    f"Action {action} expects arguments matching {signature}, received {args}."
+                ) from exc
+        else:
+            if args:
+                raise ValueError(
+                    f"Action {action} does not take any arguments. Received unexpected values: {args}."
+                )
+            message = formatter
 
         # Send the generated message via serial communication
         self.sendMessage(message)

--- a/src/Shield_Class.py
+++ b/src/Shield_Class.py
@@ -27,6 +27,7 @@ SPDX-License-Identifier: LGLPV2.1
 
 #Python modules import
 import inspect
+import struct
 import time, serial
 
 class Shield_Device:
@@ -152,6 +153,137 @@ class Shield_Device:
 
         # Send the end of line
         self.shield_serialObj.write(b'\r\n')
+
+
+    def wait_for_scope_record(self, timeout=20.0):
+        """Wait for a scope record dump and decode it into structured samples.
+
+        Parameters
+        ----------
+        timeout: float, optional
+            Maximum number of seconds to wait for the full capture.  The timer
+            covers the entire transaction between the ``begin record`` and
+            ``end record`` markers.
+
+        Returns
+        -------
+        dict
+            A dictionary with the following keys:
+
+            ``columns``
+                Tuple of column names advertised in the record header.
+
+            ``index``
+                Optional integer index reported by the firmware (``None`` if
+                missing).
+
+            ``samples``
+                List of dictionaries, each mapping a column name to the float
+                value decoded for a single sample.
+
+            ``raw``
+                The raw hexadecimal payload lines as emitted by the firmware.
+
+        Raises
+        ------
+        TimeoutError
+            If the record terminator is not received before *timeout*
+            elapses.
+        RuntimeError
+            If the capture is malformed (missing header or inconsistent
+            payload size).
+        """
+
+        deadline = time.time() + timeout
+        serial_obj = self.shield_serialObj
+        in_record = False
+        header_lines = []
+        payload_lines = []
+
+        while time.time() < deadline:
+            raw_line = serial_obj.readline()
+            if not raw_line:
+                continue
+
+            try:
+                line = raw_line.decode("ascii", errors="ignore").strip()
+            except UnicodeDecodeError:
+                # Skip undecodable garbage and keep listening.
+                continue
+
+            if not line:
+                continue
+
+            if line == "begin record":
+                in_record = True
+                header_lines.clear()
+                payload_lines.clear()
+                continue
+
+            if not in_record:
+                # Ignore any other console output.
+                continue
+
+            if line == "end record":
+                return self._parse_scope_record(header_lines, payload_lines)
+
+            if line.startswith("#") and len(header_lines) < 2:
+                header_lines.append(line)
+                continue
+
+            payload_lines.append(line)
+
+        raise TimeoutError("Timed out waiting for the scope record to finish.")
+
+
+    @staticmethod
+    def _parse_scope_record(header_lines, payload_lines):
+        if not header_lines:
+            raise RuntimeError("Scope record did not include a header line.")
+
+        header = header_lines[0].lstrip("#").strip()
+        columns = [token.strip() for token in header.split(",") if token.strip()]
+
+        record_index = None
+        if len(header_lines) > 1:
+            candidate = header_lines[1].lstrip("#").strip()
+            if candidate:
+                try:
+                    record_index = int(candidate)
+                except ValueError:
+                    # Some firmwares reuse this line for additional headers.
+                    pass
+
+        if not columns:
+            raise RuntimeError("Scope record header did not expose any columns.")
+
+        floats = []
+        for entry in payload_lines:
+            try:
+                floats.append(struct.unpack('>f', bytes.fromhex(entry))[0])
+            except (ValueError, struct.error):
+                # Ignore malformed entries but keep track of the raw payload.
+                continue
+
+        stride = len(columns)
+        if stride == 0 or len(floats) < stride:
+            samples = []
+        else:
+            trimmed_length = len(floats) - (len(floats) % stride)
+            samples = [
+                {
+                    column: floats[offset + idx]
+                    for idx, column in enumerate(columns)
+                }
+                for offset in range(0, trimmed_length, stride)
+            ]
+
+        return {
+            "columns": tuple(columns),
+            "index": record_index,
+            "samples": samples,
+            "raw": tuple(payload_lines),
+        }
 
 
     def getMeasurement(self, measurement_type):

--- a/src/Shield_Class.py
+++ b/src/Shield_Class.py
@@ -79,7 +79,7 @@ class Shield_Device:
                                     "V2": {"index": 7},
                                     "M2": {"index": 8},
                                     "T2": {"index": 9},
-                                    "D2": {"index": 10},
+                                    "D3": {"index": 10},
                                     "I3": {"index": 11},
                                     "V3": {"index": 12},
                                     "M3": {"index": 13},
@@ -91,7 +91,7 @@ class Shield_Device:
                                     "CR": {"index": 19},
                                     "RS": {"index": 20}}
 
-        if self.shield_type is "TWIST" :
+        if self.shield_type == "TWIST" :
             self.shield_message_index = twist_message_index
             self.message_lenght = twist_message_length
 
@@ -111,6 +111,10 @@ class Shield_Device:
 
     def getSerialObjID(self):
         return self.shield_serialObj
+
+    def get_supported_measurements(self):
+        """Return the tuple of measurement identifiers exposed by the shield."""
+        return tuple(self.shield_message_index.keys())
 
 
     def sendMessage(self,Message):
@@ -151,27 +155,36 @@ class Shield_Device:
 
     def getMeasurement(self, measurement_type):
         """
-        Retrieves the TWIST measurement value based on the measurement type.
-        This MUST be called when the Twist is in POWER ON
+        Retrieve the latest measurement published by the shield for the given
+        ``measurement_type``. This method must be called while the converter is
+        in ``POWER ON`` so that telemetry frames are streamed on the serial
+        link.
 
-        Parameters:
-            - self: Instance of the class containing the measurement methods.
-            - measurement_type (str): Type of measurement to retrieve.
-              Supported types are 'V1', 'V2', 'V3','VH', 'I1', 'I2', 'I3','IH', 'M1', 'M2', 'M3', 'T1', 'T2', 'T3','CT'.
+        Parameters
+        ----------
+        measurement_type: str
+            Identifier of the measurement to read (for example ``"V1"`` or
+            ``"IH"``). The list of supported identifiers depends on the shield
+            family that was selected when instantiating :class:`Shield_Device`.
 
+        Returns
+        -------
+        float
+            The value parsed from the latest telemetry frame for the requested
+            measurement.
 
-        Returns:
-            - Measurement value corresponding to the specified measurement type.
-
-        Raises:
-            - ValueError: If an invalid measurement type is provided.
+        Raises
+        ------
+        ValueError
+            If ``measurement_type`` is not part of the measurements advertised
+            by the current shield.
         """
         if measurement_type not in self.shield_message_index:
-            raise ValueError("Invalid measurement type. Supported types are:    \
-                             'V1', 'V2', 'V3','VH',                             \
-                             'I1', 'I2', 'I3','IH',                             \
-                             'M1', 'M2', 'M3',                                  \
-                             'T1', 'T2', 'T3'.")
+            supported = ", ".join(sorted(self.shield_message_index.keys()))
+            raise ValueError(
+                "Invalid measurement type for {shield}. Supported types are: {supported}."
+                .format(shield=self.shield_type, supported=supported)
+            )
 
         # time.sleep(self.short_delay)
         index_meas = self.shield_message_index[measurement_type]["index"]

--- a/src/comm_protocol.cpp
+++ b/src/comm_protocol.cpp
@@ -64,6 +64,19 @@ extern float32_t T3_value;
 
 
 extern float32_t duty_cycle;
+extern test_profile_t current_test_profile;
+extern float32_t wave_frequency_hz;
+extern float32_t wave_amplitude;
+extern float32_t wave_offset;
+extern float32_t wave_theta;
+extern float32_t chirp_start_frequency;
+extern float32_t chirp_end_frequency;
+extern float32_t chirp_duration_s;
+extern float32_t chirp_elapsed_s;
+extern float32_t chirp_rate_hz_per_s;
+extern bool chirp_loop_enabled;
+extern bool waveform_stop_requested;
+extern bool enable_test_leg;
 bool is_downloading;
 bool enable_acq;
 extern uint32_t num_trig_ratio_point;
@@ -106,8 +119,15 @@ cmdToSettings_t power_settings[] = {
     {"_d", dutyHandler},
 };
 
+void chirpHandler(uint8_t test_leg, uint8_t setting_position);
+void fixedFrequencyHandler(uint8_t test_leg, uint8_t setting_position);
+void waveStopHandler(uint8_t test_leg, uint8_t setting_position);
+
 testSensiSettings_t testSensi_settings[] = {
     {"_r", vrefHandler},
+    {"_c", chirpHandler},
+    {"_f", fixedFrequencyHandler},
+    {"_s", waveStopHandler},
 };
 
 cmdToState_t default_commands[] = {
@@ -331,15 +351,190 @@ void dutyHandler(uint8_t power_leg, uint8_t setting_position) {
 
 void vrefHandler(uint8_t power_leg, uint8_t setting_position) {
     // Check if the bufferstr starts with "_d_"
-    if (strncmp(bufferstr, "_LEG1_r_", 8) == 0 || 
-        strncmp(bufferstr, "_LEG2_r_", 8) == 0 || 
-        strncmp(bufferstr, "_LEG3_r_", 8) == 0) 
+    if (strncmp(bufferstr, "_LEG1_r_", 8) == 0 ||
+        strncmp(bufferstr, "_LEG2_r_", 8) == 0 ||
+        strncmp(bufferstr, "_LEG3_r_", 8) == 0)
     {
         // Extract the duty cycle value from the protocol message
         V_ref = atof(bufferstr + 8);
+        current_test_profile = TEST_PROFILE_SENSI;
+        is_test_performing = true;
+        dc_open_cycle = true;
+        waveform_stop_requested = false;
+        enable_test_leg = false;
+        chirp_elapsed_s = 0.0F;
+        wave_theta = 0.0F;
+        chirp_loop_enabled = false;
     } else {
         printk("Invalid protocol format: %s\n", bufferstr);
     }
+}
+
+static void clamp_waveform_bounds(float32_t *amplitude, float32_t *offset)
+{
+    if (*amplitude < 0.0F) {
+        *amplitude = 0.0F;
+    }
+    if (*amplitude > 0.5F) {
+        *amplitude = 0.5F;
+    }
+
+    if (*offset < *amplitude) {
+        *offset = *amplitude;
+    }
+    if (*offset > (1.0F - *amplitude)) {
+        *offset = 1.0F - *amplitude;
+    }
+    if (*offset < 0.0F) {
+        *offset = 0.0F;
+    }
+    if (*offset > 1.0F) {
+        *offset = 1.0F;
+    }
+}
+
+void chirpHandler(uint8_t test_leg_unused, uint8_t setting_position_unused)
+{
+    ARG_UNUSED(test_leg_unused);
+    ARG_UNUSED(setting_position_unused);
+
+    const char *payload = strstr(bufferstr, "_c_");
+    if (payload == NULL) {
+        printk("Invalid chirp command format: %s\n", bufferstr);
+        return;
+    }
+
+    float32_t start_freq = chirp_start_frequency;
+    float32_t end_freq = chirp_end_frequency;
+    float32_t sweep_duration = chirp_duration_s;
+    float32_t amplitude = wave_amplitude;
+    float32_t offset = wave_offset;
+    int loop = chirp_loop_enabled ? 1 : 0;
+
+    char temp_buffer[128];
+    strncpy(temp_buffer, payload + 3, sizeof(temp_buffer) - 1);
+    temp_buffer[sizeof(temp_buffer) - 1] = '\0';
+
+    char *token = strtok(temp_buffer, "_");
+    if (token != NULL) {
+        start_freq = atof(token);
+    }
+    token = strtok(NULL, "_");
+    if (token != NULL) {
+        end_freq = atof(token);
+    }
+    token = strtok(NULL, "_");
+    if (token != NULL) {
+        sweep_duration = atof(token);
+    }
+    token = strtok(NULL, "_");
+    if (token != NULL) {
+        amplitude = atof(token);
+    }
+    token = strtok(NULL, "_");
+    if (token != NULL) {
+        offset = atof(token);
+    }
+    token = strtok(NULL, "_");
+    if (token != NULL) {
+        loop = atoi(token);
+    }
+
+    if (sweep_duration <= 0.0F) {
+        printk("Invalid chirp duration %.3f\n", (double)sweep_duration);
+        return;
+    }
+
+    if (start_freq < 0.0F) {
+        start_freq = 0.0F;
+    }
+    if (end_freq < 0.0F) {
+        end_freq = 0.0F;
+    }
+
+    clamp_waveform_bounds(&amplitude, &offset);
+
+    chirp_start_frequency = start_freq;
+    chirp_end_frequency = end_freq;
+    chirp_duration_s = sweep_duration;
+    chirp_elapsed_s = 0.0F;
+    chirp_rate_hz_per_s = (chirp_duration_s > 0.0F) ?
+        (chirp_end_frequency - chirp_start_frequency) / chirp_duration_s : 0.0F;
+    wave_amplitude = amplitude;
+    wave_offset = offset;
+    wave_frequency_hz = chirp_start_frequency;
+    wave_theta = 0.0F;
+    chirp_loop_enabled = (loop != 0);
+    waveform_stop_requested = false;
+    enable_test_leg = false;
+
+    current_test_profile = TEST_PROFILE_CHIRP;
+    is_test_performing = true;
+    dc_open_cycle = false;
+}
+
+void fixedFrequencyHandler(uint8_t test_leg_unused, uint8_t setting_position_unused)
+{
+    ARG_UNUSED(test_leg_unused);
+    ARG_UNUSED(setting_position_unused);
+
+    const char *payload = strstr(bufferstr, "_f_");
+    if (payload == NULL) {
+        printk("Invalid fixed frequency command format: %s\n", bufferstr);
+        return;
+    }
+
+    float32_t frequency = wave_frequency_hz;
+    float32_t amplitude = wave_amplitude;
+    float32_t offset = wave_offset;
+
+    char temp_buffer[96];
+    strncpy(temp_buffer, payload + 3, sizeof(temp_buffer) - 1);
+    temp_buffer[sizeof(temp_buffer) - 1] = '\0';
+
+    char *token = strtok(temp_buffer, "_");
+    if (token != NULL) {
+        frequency = atof(token);
+    }
+    token = strtok(NULL, "_");
+    if (token != NULL) {
+        amplitude = atof(token);
+    }
+    token = strtok(NULL, "_");
+    if (token != NULL) {
+        offset = atof(token);
+    }
+
+    if (frequency <= 0.0F) {
+        printk("Invalid fixed frequency %.3f\n", (double)frequency);
+        return;
+    }
+
+    clamp_waveform_bounds(&amplitude, &offset);
+
+    wave_frequency_hz = frequency;
+    wave_amplitude = amplitude;
+    wave_offset = offset;
+    chirp_start_frequency = wave_frequency_hz;
+    chirp_end_frequency = wave_frequency_hz;
+    chirp_duration_s = 0.0F;
+    chirp_rate_hz_per_s = 0.0F;
+    chirp_elapsed_s = 0.0F;
+    wave_theta = 0.0F;
+    chirp_loop_enabled = true;
+    waveform_stop_requested = false;
+    enable_test_leg = false;
+
+    current_test_profile = TEST_PROFILE_FIXED_FREQ;
+    is_test_performing = true;
+    dc_open_cycle = false;
+}
+
+void waveStopHandler(uint8_t test_leg_unused, uint8_t setting_position_unused)
+{
+    ARG_UNUSED(test_leg_unused);
+    ARG_UNUSED(setting_position_unused);
+    waveform_stop_requested = true;
 }
 
 void referenceHandler(uint8_t power_leg, uint8_t setting_position){
@@ -530,8 +725,6 @@ void testSensiHandler()
             if (testSensi_settings[i].func != NULL)
             {
                 testSensi_settings[i].func(test_leg, i); //pointer to the handler function associated with the command
-                is_test_performing = true;
-                dc_open_cycle = true;
             }
             return;
         }

--- a/src/comm_protocol.cpp
+++ b/src/comm_protocol.cpp
@@ -365,6 +365,7 @@ void vrefHandler(uint8_t power_leg, uint8_t setting_position) {
         chirp_elapsed_s = 0.0F;
         wave_theta = 0.0F;
         chirp_loop_enabled = false;
+        scope_prepare_for_new_test();
     } else {
         printk("Invalid protocol format: %s\n", bufferstr);
     }
@@ -471,6 +472,7 @@ void chirpHandler(uint8_t test_leg_unused, uint8_t setting_position_unused)
     current_test_profile = TEST_PROFILE_CHIRP;
     is_test_performing = true;
     dc_open_cycle = false;
+    scope_prepare_for_new_test();
 }
 
 void fixedFrequencyHandler(uint8_t test_leg_unused, uint8_t setting_position_unused)
@@ -528,6 +530,7 @@ void fixedFrequencyHandler(uint8_t test_leg_unused, uint8_t setting_position_unu
     current_test_profile = TEST_PROFILE_FIXED_FREQ;
     is_test_performing = true;
     dc_open_cycle = false;
+    scope_prepare_for_new_test();
 }
 
 void waveStopHandler(uint8_t test_leg_unused, uint8_t setting_position_unused)

--- a/src/comm_protocol.h
+++ b/src/comm_protocol.h
@@ -206,6 +206,7 @@ extern float32_t chirp_rate_hz_per_s;
 extern bool chirp_loop_enabled;
 extern bool waveform_stop_requested;
 extern bool enable_test_leg;
+void scope_prepare_for_new_test(void);
 extern uint8_t num_tracking_vars;
 extern uint8_t num_power_settings;
 extern uint8_t num_default_commands;

--- a/src/comm_protocol.h
+++ b/src/comm_protocol.h
@@ -163,6 +163,14 @@ typedef struct {
 } scopeToCommand_t;
 
 
+typedef enum {
+    TEST_PROFILE_NONE = 0,
+    TEST_PROFILE_SENSI,
+    TEST_PROFILE_CHIRP,
+    TEST_PROFILE_FIXED_FREQ,
+} test_profile_t;
+
+
 /**
  * @brief Structure representing various measurements and statuses.
  *
@@ -180,11 +188,24 @@ typedef struct {
 extern TrackingVariables tracking_vars[NUM_OF_TRACK_VARIABLES];
 extern PowerLegSettings power_leg_settings[NUM_OF_LEGS];
 extern cmdToSettings_t power_settings[7];
-extern testSensiSettings_t testSensi_settings[7];
+extern testSensiSettings_t testSensi_settings[4];
 extern cmdToState_t default_commands[3];
 extern scopeToCommand_t scope_commands[2];
 
 extern tester_states_t mode;
+extern test_profile_t current_test_profile;
+extern float32_t wave_frequency_hz;
+extern float32_t wave_amplitude;
+extern float32_t wave_offset;
+extern float32_t wave_theta;
+extern float32_t chirp_start_frequency;
+extern float32_t chirp_end_frequency;
+extern float32_t chirp_duration_s;
+extern float32_t chirp_elapsed_s;
+extern float32_t chirp_rate_hz_per_s;
+extern bool chirp_loop_enabled;
+extern bool waveform_stop_requested;
+extern bool enable_test_leg;
 extern uint8_t num_tracking_vars;
 extern uint8_t num_power_settings;
 extern uint8_t num_default_commands;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@
 #include "arm_math_types.h"
 #include <ScopeMimicry.h>
 #include "CommunicationAPI.h"
+#include "trigo.h"
 
 #define RECORD_SIZE 128 // Number of point to record
 
@@ -49,6 +50,11 @@ void setup_routine(); // Setups the hardware and software of the system
 void loop_application_task();   // Code to be executed in the background task
 void loop_communication_task();   // Code to be executed in the background task
 void loop_control_task();     // Code to be executed in real time in the critical task
+static void run_sensitivity_sequence(void);
+static void run_chirp_sequence(void);
+static void run_fixed_frequency_sequence(void);
+static void stop_all_tests(bool request_dump);
+static float32_t clamp_duty_cycle(float32_t value);
 
 
 //--------------USER VARIABLES DECLARATIONS----------------------
@@ -131,7 +137,19 @@ static uint32_t print_counter = 0;
 
 static float32_t local_analog_value=0;
 
-static bool enable_test_leg = false;
+bool enable_test_leg = false;
+test_profile_t current_test_profile = TEST_PROFILE_NONE;
+bool waveform_stop_requested = false;
+float32_t wave_theta = 0.0F;
+float32_t wave_frequency_hz = 50.0F;
+float32_t wave_amplitude = 0.4F;
+float32_t wave_offset = 0.5F;
+float32_t chirp_start_frequency = 50.0F;
+float32_t chirp_end_frequency = 5000.0F;
+float32_t chirp_duration_s = 1.0F;
+float32_t chirp_elapsed_s = 0.0F;
+float32_t chirp_rate_hz_per_s = 0.0F;
+bool chirp_loop_enabled = false;
 float32_t duty_cycle = lower_bound;
 float32_t duty_cycle_50_perc = 0.5;
 float32_t duty_cycle_70_perc = 0.7;
@@ -305,6 +323,204 @@ void loop_application_task()
 }
 
 
+static float32_t clamp_duty_cycle(float32_t value)
+{
+    if (value < 0.0F) {
+        return 0.0F;
+    }
+    if (value > 1.0F) {
+        return 1.0F;
+    }
+    return value;
+}
+
+static void stop_all_tests(bool request_dump)
+{
+    if (request_dump) {
+        is_downloading = true;
+    }
+
+    waveform_stop_requested = false;
+    is_test_performing = false;
+    current_test_profile = TEST_PROFILE_NONE;
+    dc_open_cycle = false;
+    enable_test_leg = false;
+    chirp_elapsed_s = 0.0F;
+    chirp_loop_enabled = false;
+    wave_theta = 0.0F;
+    trig_ratio = begin_trig_ratio;
+    cpt = 1;
+    duty_cycle = starting_duty_cycle;
+    power_leg_settings[test_leg].duty_cycle = duty_cycle;
+    shield.power.setDutyCycle(test_leg, duty_cycle);
+    shield.power.stop(test_leg);
+    buffer_scope = scope.get_buffer();
+    buffer_size = scope.get_buffer_size() >> 2;
+
+    if (test_leg == LEG1) {
+        pid1.reset();
+    }
+
+    if (test_leg == LEG2) {
+        pid2.reset();
+    }
+#ifdef CONFIG_SHIELD_OWNVERTER
+    if (test_leg == LEG3) {
+        pid3.reset();
+    }
+#endif
+
+    mode = IDLE;
+}
+
+static void run_sensitivity_sequence(void)
+{
+    if (!enable_test_leg) {
+        shield.power.start(test_leg);
+        enable_test_leg = true;
+        duty_cycle = lower_bound;
+        shield.power.setDutyCycle(test_leg, duty_cycle);
+    }
+
+    scope.acquire();
+    a_trigger();
+    scope.has_trigged();
+
+    if (dc_open_cycle) {
+        if (test_leg == LEG1) {
+            duty_cycle = pid1.calculateWithReturn(
+                V_ref,
+                *power_leg_settings[test_leg].tracking_variable);
+        }
+
+        if (test_leg == LEG2) {
+            duty_cycle = pid2.calculateWithReturn(
+                V_ref,
+                *power_leg_settings[test_leg].tracking_variable);
+        }
+#ifdef CONFIG_SHIELD_OWNVERTER
+        if (test_leg == LEG3) {
+            duty_cycle = pid3.calculateWithReturn(
+                V_ref,
+                *power_leg_settings[test_leg].tracking_variable);
+        }
+#endif
+        duty_cycle = clamp_duty_cycle(duty_cycle);
+        shield.power.setDutyCycle(test_leg, duty_cycle);
+        power_leg_settings[test_leg].duty_cycle = duty_cycle;
+        cpt++;
+        if (cpt >= cpt_close_loop) {
+            dc_open_cycle = false;
+        }
+        return;
+    }
+
+    if (!dc_open_cycle && cpt < cpt_open_loop) {
+        if ((cpt < cpt_step_begin) || (cpt > cpt_step_end)) {
+            duty_cycle = duty_cycle_50_perc;
+            shield.power.setDutyCycle(test_leg, duty_cycle);
+        }
+
+        if ((cpt >= cpt_step_begin) && (cpt <= cpt_step_begin + 1)) {
+            duty_cycle = duty_cycle_70_perc;
+            shield.power.setDutyCycle(test_leg, duty_cycle);
+            power_leg_settings[test_leg].duty_cycle = duty_cycle;
+        }
+
+        if ((cpt >= cpt_step_begin + 2) && (cpt <= cpt_step_end - 2)) {
+            duty_cycle = duty_cycle_70_perc;
+            shield.power.setDutyCycle(test_leg, duty_cycle);
+            power_leg_settings[test_leg].duty_cycle = duty_cycle;
+        }
+
+        if ((cpt >= cpt_step_end - 1) && (cpt <= cpt_step_end)) {
+            duty_cycle -= duty_cyle_step;
+            duty_cycle = clamp_duty_cycle(duty_cycle);
+            shield.power.setDutyCycle(test_leg, duty_cycle);
+            power_leg_settings[test_leg].duty_cycle = duty_cycle;
+        }
+
+        cpt++;
+        return;
+    }
+
+    power_leg_settings[test_leg].duty_cycle = duty_cycle;
+    shield.power.setDutyCycle(test_leg, duty_cycle);
+    trig_ratio += (end_trig_ratio - begin_trig_ratio) /
+                  (float32_t)num_trig_ratio_point;
+    if (trig_ratio > end_trig_ratio) {
+        trig_ratio = begin_trig_ratio;
+    }
+    shield.power.setTriggerValue(test_leg, trig_ratio);
+    cpt++;
+
+    if (cpt >= 1000) {
+        stop_all_tests(true);
+    }
+}
+
+static void run_chirp_sequence(void)
+{
+    if (!enable_test_leg) {
+        shield.power.start(test_leg);
+        enable_test_leg = true;
+        duty_cycle = starting_duty_cycle;
+        shield.power.setDutyCycle(test_leg, duty_cycle);
+    }
+
+    scope.acquire();
+    a_trigger();
+    scope.has_trigged();
+
+    float32_t w0 = 2.0F * PI * wave_frequency_hz;
+    wave_theta = ot_modulo_2pi(wave_theta + w0 * Ts);
+    float32_t duty = ot_sin(wave_theta) * wave_amplitude + wave_offset;
+    duty = clamp_duty_cycle(duty);
+
+    duty_cycle = duty;
+    power_leg_settings[test_leg].duty_cycle = duty_cycle;
+    shield.power.setDutyCycle(test_leg, duty_cycle);
+
+    chirp_elapsed_s += Ts;
+    if (chirp_duration_s > 0.0F) {
+        if (chirp_elapsed_s >= chirp_duration_s) {
+            if (chirp_loop_enabled) {
+                chirp_elapsed_s = 0.0F;
+                wave_frequency_hz = chirp_start_frequency;
+            } else {
+                stop_all_tests(true);
+                return;
+            }
+        } else {
+            wave_frequency_hz = chirp_start_frequency +
+                                (chirp_rate_hz_per_s * chirp_elapsed_s);
+        }
+    }
+}
+
+static void run_fixed_frequency_sequence(void)
+{
+    if (!enable_test_leg) {
+        shield.power.start(test_leg);
+        enable_test_leg = true;
+        duty_cycle = starting_duty_cycle;
+        shield.power.setDutyCycle(test_leg, duty_cycle);
+    }
+
+    scope.acquire();
+    a_trigger();
+    scope.has_trigged();
+
+    float32_t w0 = 2.0F * PI * wave_frequency_hz;
+    wave_theta = ot_modulo_2pi(wave_theta + w0 * Ts);
+    float32_t duty = ot_sin(wave_theta) * wave_amplitude + wave_offset;
+    duty = clamp_duty_cycle(duty);
+
+    duty_cycle = duty;
+    power_leg_settings[test_leg].duty_cycle = duty_cycle;
+    shield.power.setDutyCycle(test_leg, duty_cycle);
+}
+
 void loop_control_task()
 {
     // shield.sensors.getValues
@@ -326,6 +542,11 @@ void loop_control_task()
     meas_data = shield.sensors.getLatestValue(I_HIGH);
     if (meas_data != NO_VALUE)
         I_high_value = meas_data;
+
+    if (waveform_stop_requested) {
+        bool request_dump = is_test_performing;
+        stop_all_tests(request_dump);
+    }
 
     if (test_leg == LEG1) {
         meas_tab = shield.sensors.getRawValues(V1_LOW, nb_meas_data_values);
@@ -439,112 +660,20 @@ void loop_control_task()
             // shield.power.start(LEG1);
             
 
-            if (is_test_performing ) {
-                     
-                if (!enable_test_leg){
-                    shield.power.start(test_leg);
-                    enable_test_leg = true;
-                    duty_cycle = lower_bound;
-                    shield.power.setDutyCycle(test_leg, duty_cycle);                    
+            if (is_test_performing) {
+                switch (current_test_profile) {
+                    case TEST_PROFILE_CHIRP:
+                        run_chirp_sequence();
+                        break;
+                    case TEST_PROFILE_FIXED_FREQ:
+                        run_fixed_frequency_sequence();
+                        break;
+                    case TEST_PROFILE_SENSI:
+                    default:
+                        run_sensitivity_sequence();
+                        break;
                 }
-
-                scope.acquire(); // enable scope acquisition
-                a_trigger();
-                scope.has_trigged();
-
-                if (dc_open_cycle){
-                    
-                    if (test_leg == LEG1) {
-                        duty_cycle = pid1.calculateWithReturn(V_ref , 
-                                                            *power_leg_settings[test_leg].tracking_variable);
-                    }
-
-                    if (test_leg == LEG2) {
-                        duty_cycle = pid2.calculateWithReturn(V_ref , 
-                                                            *power_leg_settings[test_leg].tracking_variable);
-                    }
-                #ifdef CONFIG_SHIELD_OWNVERTER
-                    if (test_leg == LEG3) {
-                        duty_cycle = pid3.calculateWithReturn(V_ref , 
-                                                            *power_leg_settings[test_leg].tracking_variable);
-                    }
-                #endif
-                    shield.power.setDutyCycle(test_leg, duty_cycle);
-                    power_leg_settings[test_leg].duty_cycle = duty_cycle;
-                    cpt++;
-                    if (cpt >= cpt_close_loop) dc_open_cycle = false;
-                } 
-                else if (dc_open_cycle == false && cpt < cpt_open_loop){
-                        if ((cpt < cpt_step_begin) || (cpt > cpt_step_end)) {
-                            duty_cycle = duty_cycle_50_perc;
-                            shield.power.setDutyCycle(test_leg, duty_cycle);
-                        }
-
-                        // ramp up the duty cycle
-                        if ((cpt>= cpt_step_begin) && (cpt <= cpt_step_begin+1)) {
-                            // duty_cycle += duty_cyle_step; 
-                            duty_cycle = duty_cycle_70_perc;
-                            shield.power.setDutyCycle(test_leg, duty_cycle);
-                            power_leg_settings[test_leg].duty_cycle = duty_cycle;
-                        }
-
-                        //  duty cycle at 70% 
-                        if ((cpt >= cpt_step_begin + 2) && (cpt <= cpt_step_end - 2)){
-                            duty_cycle = duty_cycle_70_perc;
-                            shield.power.setDutyCycle(test_leg, duty_cycle);
-                            power_leg_settings[test_leg].duty_cycle = duty_cycle;
-                        }
-                        
-                        // ramp down the duty cycle
-                        if ((cpt >= cpt_step_end-1) && (cpt <= cpt_step_end)) {
-                            duty_cycle -= duty_cyle_step; 
-                            shield.power.setDutyCycle(test_leg, duty_cycle);
-                            power_leg_settings[test_leg].duty_cycle = duty_cycle;
-                        }
-            
-                        cpt++;
-                        
-                } 
-                else {
-                    power_leg_settings[test_leg].duty_cycle = duty_cycle;
-                    shield.power.setDutyCycle(test_leg,duty_cycle);
-                    trig_ratio += (end_trig_ratio - begin_trig_ratio) / (float32_t)num_trig_ratio_point;
-                    if (trig_ratio > end_trig_ratio) { // make a cycle
-                        trig_ratio = begin_trig_ratio;
-                    }
-                    shield.power.setTriggerValue(test_leg, trig_ratio);
-                    cpt++;
-                    
-                    if (cpt >= 1000) {
-                        is_test_performing = false; 
-                        is_downloading = true; 
-                        cpt = 1; 
-                        trig_ratio = begin_trig_ratio;
-                        duty_cycle = 0.1;
-                        power_leg_settings[test_leg].duty_cycle = duty_cycle;
-                        shield.power.setDutyCycle(test_leg,duty_cycle);
-                        shield.power.stop(test_leg);
-                        buffer_scope = scope.get_buffer();
-                        buffer_size = scope.get_buffer_size() >> 2; // we divide by 4 (4 bytes per float data)
-                        if (test_leg == LEG1) {
-                            pid1.reset();
-                        }
-
-                        if (test_leg == LEG2) {
-                            pid2.reset();
-                        }
-                    #ifdef CONFIG_SHIELD_OWNVERTER
-                        if (test_leg == LEG3) {
-                            pid3.reset();
-                        }
-                    #endif
-                        enable_test_leg = false;
-                        mode = IDLE;
-                    }
-                }
-                
-            } 
-            else {
+            } else {
                 //Tests if the legs were turned off and does it only once ]
                 if(!pwm_enable_leg_1 && power_leg_settings[LEG1].settings[BOOL_LEG]) {shield.power.start(LEG1); pwm_enable_leg_1 = true;}
                 if(!pwm_enable_leg_2 && power_leg_settings[LEG2].settings[BOOL_LEG]) {shield.power.start(LEG2); pwm_enable_leg_2 = true;}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,6 +138,31 @@ static uint32_t print_counter = 0;
 static float32_t local_analog_value=0;
 
 bool enable_test_leg = false;
+
+void scope_prepare_for_new_test(void)
+{
+    /*
+     * Disable the acquisition gate first so the ScopeMimicry instance waits
+     * for the next rising edge before it starts filling its circular buffer.
+     * This prevents the following capture from reusing a portion of the
+     * previous test when the firmware re-arms the scope very quickly.
+     */
+    enable_acq = false;
+
+    /* Reset the dump cursor and clear the "already triggered" flag so the
+     * Python host receives a fresh record whose sample zero corresponds to
+     * the beginning of the upcoming automated test. Calling has_trigged()
+     * resets the internal latch inside ScopeMimicry.
+     */
+    scope.reset_dump();
+    scope.has_trigged();
+
+    /* Re-enable the trigger gate right away. On the next control-loop
+     * iteration the acquisition function will observe enable_acq = true and
+     * start writing the newly generated waveform from sample index zero.
+     */
+    enable_acq = true;
+}
 test_profile_t current_test_profile = TEST_PROFILE_NONE;
 bool waveform_stop_requested = false;
 float32_t wave_theta = 0.0F;
@@ -340,6 +365,7 @@ static void stop_all_tests(bool request_dump)
         is_downloading = true;
     }
 
+    enable_acq = false;
     waveform_stop_requested = false;
     is_test_performing = false;
     current_test_profile = TEST_PROFILE_NONE;

--- a/src/plot_scope_records.py
+++ b/src/plot_scope_records.py
@@ -1,0 +1,134 @@
+"""Plot the latest ScopeMimicry captures for the automated tests.
+
+This helper scans the ``scope_records`` directory (created by
+``SPIN_COMM_test_script.py``) and opens the most recent CSV files for the
+three automated sequences:
+
+* réponse en échelon (``TEST_SENSI``)
+* balayage fréquentiel (``TEST_CHIRP``)
+* sinusoïde à fréquence fixe (``TEST_FIXED_FREQ``)
+
+Each capture is plotted in its own matplotlib figure so the behaviour of the
+converter can be inspected visually after a test run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence
+
+try:
+    import matplotlib.pyplot as plt
+except ModuleNotFoundError as exc:  # pragma: no cover - user feedback only
+    raise SystemExit(
+        "matplotlib est requis pour tracer les captures (pip install matplotlib)."
+    ) from exc
+
+
+@dataclass(frozen=True)
+class TestConfig:
+    """Describe how CSV files are named for a given automated test."""
+
+    display_name: str
+    file_suffix: str
+
+
+TESTS: Sequence[TestConfig] = (
+    TestConfig(display_name="TEST_SENSI", file_suffix="test_sensi"),
+    TestConfig(display_name="TEST_CHIRP", file_suffix="test_chirp"),
+    TestConfig(display_name="TEST_FIXED_FREQ", file_suffix="test_fixed_freq"),
+)
+
+
+def find_latest_csv(directory: Path, suffix: str) -> Path | None:
+    """Return the newest CSV file whose name ends with ``suffix``.
+
+    The acquisition files are timestamped (``YYYYmmdd-HHMMSS-ffffff``). Sorting
+    alphabetically therefore also sorts chronologically, so the last entry is
+    the most recent capture.
+    """
+
+    pattern = f"*_{suffix}.csv"
+    matches = sorted(directory.glob(pattern))
+    if not matches:
+        return None
+    return matches[-1]
+
+
+def load_csv_series(csv_path: Path) -> Dict[str, List[float]]:
+    """Load numerical series from ``csv_path``.
+
+    Columns that cannot be converted to ``float`` are silently skipped.
+    """
+
+    series: Dict[str, List[float]] = defaultdict(list)
+    with csv_path.open("r", newline="") as stream:
+        reader = csv.DictReader(stream)
+        for row in reader:
+            for column, value in row.items():
+                if value is None or value == "":
+                    continue
+                try:
+                    series[column].append(float(value))
+                except ValueError:
+                    # Skip non-numeric columns
+                    continue
+    return series
+
+
+def plot_series(test: TestConfig, series: Dict[str, List[float]]) -> None:
+    """Render the measurement series in a dedicated matplotlib figure."""
+
+    if not series:
+        print(f"Aucune donnée exploitable pour {test.display_name}.")
+        return
+
+    plt.figure()
+    for column, values in series.items():
+        if not values:
+            continue
+        plt.plot(range(len(values)), values, label=column)
+
+    plt.title(f"Dernière capture – {test.display_name}")
+    plt.xlabel("Échantillon")
+    plt.ylabel("Valeur")
+    plt.grid(True, which="both", linestyle="--", linewidth=0.5)
+    plt.legend()
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "directory",
+        nargs="?",
+        default="scope_records",
+        type=Path,
+        help="Dossier contenant les captures CSV (par défaut: scope_records)",
+    )
+    args = parser.parse_args(argv)
+
+    directory: Path = args.directory
+    if not directory.exists():
+        raise SystemExit(f"Le dossier {directory} est introuvable.")
+
+    for test in TESTS:
+        csv_path = find_latest_csv(directory, test.file_suffix)
+        if csv_path is None:
+            print(
+                f"Aucun fichier correspondant à {test.display_name} dans {directory}."
+            )
+            continue
+
+        print(f"Chargement de {csv_path} pour {test.display_name}…")
+        series = load_csv_series(csv_path)
+        plot_series(test, series)
+
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expose new chirp, fixed-frequency and stop commands in the Python interface and sample script
- extend the serial protocol to parse the new waveform commands and track waveform parameters
- add firmware helpers to run chirp and fixed-frequency excitations with a unified stop routine

## Testing
- python -m compileall DATA_POWER/src/Shield_Class.py DATA_POWER/src/SPIN_COMM_test_script.py


------
https://chatgpt.com/codex/tasks/task_e_68d2a3fe034c8320af44627aa820b19d